### PR TITLE
Changes to read data from LP socketchannel.

### DIFF
--- a/MultiTcp/src/main/java/edu/indiana/p538/PacketAnalyzer.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/PacketAnalyzer.java
@@ -24,8 +24,10 @@ public class PacketAnalyzer {
 
         try {
             InetAddress ipAddress = InetAddress.getByAddress(DatatypeConverter.parseHexBinary(Utils.bytesToHex(ip)));
-            int portNumber=Utils.hextoDecimal(Utils.bytesToHex(port));
-            return new InetSocketAddress(ipAddress,portNumber);
+            ByteBuffer buf = ByteBuffer.wrap(port);
+            buf.order(ByteOrder.LITTLE_ENDIAN);
+            int portNum = (int) buf.getShort();
+            return new InetSocketAddress(ipAddress,portNum);
         }
         catch(UnknownHostException e){
             throw new RuntimeException("Unknown host",e);
@@ -34,7 +36,6 @@ public class PacketAnalyzer {
 
 	public static boolean isMSyn(byte[] header){
         byte[] head3 = Arrays.copyOfRange(header, 6, 8);
-		System.out.println(Utils.bytesToHex(head3));
 		if(Utils.bytesToHex(head3).equals("FFFF")){
 			return true;
 		}

--- a/MultiTcp/src/main/java/edu/indiana/p538/Proxy.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/Proxy.java
@@ -1,6 +1,7 @@
 package edu.indiana.p538;
 
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -31,7 +32,8 @@ public class Proxy implements Runnable {
 
     private BlockingQueue<ProxyEvents> pendingEvents = new ArrayBlockingQueue<>(50);
     private ConcurrentHashMap<InetSocketAddress,SocketChannel> connectionChannelMap = new ConcurrentHashMap<>();
-    private ConcurrentHashMap<Integer,byte[]> outOfOrder = new ConcurrentHashMap<>();
+    //this map is to map connection IDs with the list of data
+    private ConcurrentHashMap<Integer,ArrayList<byte[]>> outOfOrder = new ConcurrentHashMap<>();
 
     public Proxy(int port, ProxyWorker worker) throws IOException{
         this.port = port;
@@ -61,6 +63,7 @@ public class Proxy implements Runnable {
                 Iterator<ProxyEvents> iter = this.pendingEvents.iterator();
                 while(iter.hasNext()){
                     ProxyEvents event = iter.next();
+                    this.pendingEvents.remove(event);
                     switch (event.getType()){
                         case ProxyEvents.WRITING:
                             SocketChannel connectChannel=this.connectionChannelMap.get(event.getConnInfo());
@@ -70,7 +73,9 @@ public class Proxy implements Runnable {
                         case ProxyEvents.CONNECTING:
                             connectChannel=this.connectionChannelMap.get(event.getConnInfo());
                             //Need to double check the register call.
-                            connectChannel.register(this.selector,event.getOps());
+                            //I'm attaching the connectionID with this socket for now.
+                            // We might to make this an arraylist of connectionIDs soon
+                            connectChannel.register(this.selector,event.getOps(),event.getConnId());
 
                     }
                 }
@@ -92,6 +97,7 @@ public class Proxy implements Runnable {
                             this.read(key);
                         }else if(key.isWritable()){
                             //write to the key
+                            this.write(key);
                         }
                     }
                 }
@@ -106,24 +112,21 @@ public class Proxy implements Runnable {
         ServerSocketChannel servCh = (ServerSocketChannel) key.channel();
 
         SocketChannel sockCh = servCh.accept();
-        Socket socket = sockCh.socket(); //why is this line here? is it necessary?
         sockCh.configureBlocking(false);
-
-
         //tells the selector we want to know when data is available to be read
         sockCh.register(this.selector, SelectionKey.OP_READ);
-
     }
 
     private void read(SelectionKey key) throws IOException{
         SocketChannel sockCh = (SocketChannel) key.channel();
-
         //clear the buffer. if we've reached this point again we've already passed data on
         this.readBuf.clear();
 
         int numRead;
         try{
             numRead = sockCh.read(this.readBuf);
+            key.cancel();
+            sockCh.close();
         }catch (IOException e){
             //entering here means the remote has forced the connection closed
             key.cancel();
@@ -138,39 +141,58 @@ public class Proxy implements Runnable {
             return;
         }
 
-        //hand to worker thread
-        this.worker.processData(this, sockCh, this.readBuf.array(), numRead);
+        // Since we're not attaching anything to the LP socket channel, attachment would be empty
+        //hand to worker thread only if the read is called from the LP socket
+        if(key.attachment()==null) {
+            this.worker.processData(this, sockCh, this.readBuf.array(), numRead);
+        }
+        else{
+            //Just a dummy print statement for now to view the data
+            System.out.println(new String(this.readBuf.array()));
+            key.interestOps(SelectionKey.OP_WRITE);
+
+        }
     }
 
-    protected  void send(InetSocketAddress connInfo, byte[] data){
+    protected  void send(InetSocketAddress connInfo, byte[] data,int connId){
         //TODO: IMPLEMENT
         //add it to the buffer queue, send on as we can
         //NOPE WE DO NOT NEED THE SOCKET STOP THINKING WE DO JEEZ.
-        SocketChannel connChannel=this.connectionChannelMap.get(connInfo);
+        //SocketChannel connChannel=this.connectionChannelMap.get(connInfo);
         //Null check needed
         //TODO: Add data to a list and then add to hashmap. Need to keep track of data sequence as well.
         //Need to read data into buffer here and raise ProxyDataEvent
-        //this.pendingEvents.add(new ProxyEvents(connInfo, data, ProxyEvents.WRITING,SelectionKey.OP_WRITE));
-
-        this.selector.wakeup();
+        this.pendingEvents.add(new ProxyEvents(connInfo, data, connId, ProxyEvents.WRITING,SelectionKey.OP_WRITE));
+        //Pull the data based on the connection ID
+        if(outOfOrder.containsKey(connId)){
+            ArrayList<byte[]> dataList=outOfOrder.get(connId);
+            dataList.add(data);
+            outOfOrder.put(connId,dataList);
+        }
+        else{
+            ArrayList<byte[]> dataList=new ArrayList<>(20);
+            dataList.add(data);
+            outOfOrder.put(connId,dataList);
+        }
+       // this.selector.wakeup();
     }
 
-    protected void establishConn(InetSocketAddress msgInfo, byte[] data){
+    protected void establishConn(InetSocketAddress msgInfo, byte[] data, int connId){
         //TODO: IMPLEMENT
         //add to event queue; create connection as possible
         try {
             SocketChannel serverChannel = SocketChannel.open();
             serverChannel.configureBlocking(false);
-
             // Kick off connection establishment
             //I've temporarily added port as the key to this map. Should we think of making this the connectionID?
             connectionChannelMap.put(msgInfo,serverChannel);
-
-            serverChannel.connect(msgInfo);
             //OP_CONNECT is getting masked by the call from ProxyWorker. Safe to listen to OP_WRITE here
-            this.pendingEvents.add(new ProxyEvents(msgInfo, data, ProxyEvents.CONNECTING,SelectionKey.OP_WRITE));
+            this.pendingEvents.add(new ProxyEvents(msgInfo, data, connId,ProxyEvents.CONNECTING,SelectionKey.OP_CONNECT));
+            //serverChannel.connect(msgInfo);
             //No point in waking up here as there may not be enough data to write into the channel
             //this.selector.wakeup();
+            serverChannel.connect(msgInfo);
+
         }
         catch(IOException e){
             e.printStackTrace();
@@ -181,23 +203,43 @@ public class Proxy implements Runnable {
         //TODO: IMPLEMENT
         //add to event queue; end connection as possible
         //how to close????? Yeah how to?
-        this.pendingEvents.add(new ProxyEvents(connInfo, new byte[0], SelectionKey.OP_CONNECT,ProxyEvents.ENDING));
+        //this.pendingEvents.add(new ProxyEvents(connInfo, new byte[0], SelectionKey.OP_CONNECT,ProxyEvents.ENDING));
 
         this.selector.wakeup();
     }
     private void completeConnection(SelectionKey key) throws IOException {
         SocketChannel socketChannel = (SocketChannel) key.channel();
         //Complete connecting. This would return true if the connection is successful
-        socketChannel.configureBlocking(false);
-
+        //socketChannel.configureBlocking(false);
         try {
+            System.out.println("Connected to Server");
             socketChannel.finishConnect();
         } catch (IOException e) {
+            e.printStackTrace();
             key.cancel();
             return;
         }
 
         //Since connection is established, show interest in writing data to the server
-        key.interestOps(SelectionKey.OP_WRITE);
+      //  key.interestOps(SelectionKey.OP_WRITE);
+    }
+
+    private void write(SelectionKey key) throws IOException{
+        SocketChannel sockCh = (SocketChannel) key.channel();
+        int connId=(int)key.attachment();
+        if(outOfOrder.containsKey(connId)) {
+            ArrayList<byte[]> dataList = outOfOrder.get(connId);
+            while (!dataList.isEmpty()) {
+                ByteBuffer buf = ByteBuffer.wrap(dataList.get(0));
+                int x = sockCh.write(buf);
+                if (buf.remaining() > 0) {
+                    break;
+                }
+                dataList.remove(0);
+            }
+            if (dataList.isEmpty()) {
+                key.interestOps(SelectionKey.OP_READ);
+            }
+        }
     }
 }

--- a/MultiTcp/src/main/java/edu/indiana/p538/ProxyEvents.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/ProxyEvents.java
@@ -18,12 +18,13 @@ public class ProxyEvents {
 
     private int type;
     private int ops;
-
-    protected ProxyEvents(InetSocketAddress connInfo, byte[] message, int type, int ops){
+    private int connId;
+    protected ProxyEvents(InetSocketAddress connInfo, byte[] message, int connId, int type, int ops){
         this.connInfo = connInfo;
         this.data = message;
         this.ops = ops;
         this.type=type;
+        this.connId=connId;
     }
 
     /* GETTERS */
@@ -42,6 +43,10 @@ public class ProxyEvents {
 
     protected int getType() {
         return type;
+    }
+
+    protected int getConnId() {
+        return connId;
     }
 
     /* SETTERS */

--- a/MultiTcp/src/main/java/edu/indiana/p538/ProxyWorker.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/ProxyWorker.java
@@ -42,8 +42,10 @@ public class ProxyWorker implements Runnable{
             //test for MSYN
             if(PacketAnalyzer.isMSyn(header)){
                 InetSocketAddress msgInfo = PacketAnalyzer.fetchConnectionInfo(message);
+                int connId=PacketAnalyzer.getConnId(header);
+
                 //send back to the proxy
-                (event.getProxy()).establishConn(msgInfo, message);
+                (event.getProxy()).establishConn(msgInfo, message,connId);
             }else if(PacketAnalyzer.isMFin(header)){
                 //else test for MFIN
                 InetSocketAddress msgInfo = PacketAnalyzer.fetchConnectionInfo(message);
@@ -58,9 +60,10 @@ public class ProxyWorker implements Runnable{
             }else{
                 //else process and send data
                 byte[] payload = PacketAnalyzer.getPayload(message);
-                InetSocketAddress connInfo = PacketAnalyzer.fetchConnectionInfo(header);
+                InetSocketAddress connInfo = PacketAnalyzer.fetchConnectionInfo(message);
+                int seqNumber=PacketAnalyzer.getSeqNum(header);
                 //return to the sender
-                (event.getProxy()).send(connInfo, payload);
+                (event.getProxy()).send(connInfo, payload,seqNumber);
             }
 
 


### PR DESCRIPTION
One of those pull requests that'll make you frown. 
I've registered the connection ID with the socketchannel used to connect to the server. That way when we have the channel, we can get the connID and fetch the list of byte data. We would have to modify this in case of multiple pipes.
Send method now adds data to the hashmap based on the connection ID. Sneaked in connId inside ProxyEvents as it would be easier to attach to the channel during registration.
I'm gonna test the changes now.