### PR TITLE
Changes to fix packet loss issue

### DIFF
--- a/MultiTcp/src/main/java/edu/indiana/p538/PacketAnalyzer.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/PacketAnalyzer.java
@@ -58,13 +58,20 @@ public class PacketAnalyzer {
 
     public static boolean isMFin(byte[] header){
         byte[] head3 = Arrays.copyOfRange(header, 6, 8);
-        ByteBuffer buf = ByteBuffer.wrap(head3);
+        /*ByteBuffer buf = ByteBuffer.wrap(head3);
         buf.order(ByteOrder.LITTLE_ENDIAN);
         int val = (int) buf.getShort();
 
         if(val == AppConstants.MFIN){
             return true;
         }else{
+            return false;
+        }*/
+        //Fin is identifed by FEFF and not FFFE. Need to follow up with prof on this
+        if(Utils.bytesToHex(head3).equals("FEFF")){
+            return true;
+        }
+        else{
             return false;
         }
     }
@@ -83,7 +90,7 @@ public class PacketAnalyzer {
         ByteBuffer buf = ByteBuffer.wrap(head3);
         buf.order(ByteOrder.LITTLE_ENDIAN);
         int len = (int) buf.getShort();
-
+        len-=AppConstants.MHEADER;
         return len;
     }
 
@@ -100,8 +107,9 @@ public class PacketAnalyzer {
         return (int) payload;
     }
 
-    public static byte[] getPayload(byte[] message){
-        byte[] payload = Arrays.copyOfRange(message, AppConstants.MHEADER, message.length);
+    public static byte[] getPayload(byte[] message, int offset, int messageLength){
+        //Change to ensure that in each iteration, the payload is retrieved based on the present position of tracker
+        byte[] payload = Arrays.copyOfRange(message, offset+AppConstants.MHEADER, offset+AppConstants.MHEADER+messageLength);
         return payload;
     }
 

--- a/MultiTcp/src/main/java/edu/indiana/p538/ProxyWorker.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/ProxyWorker.java
@@ -36,38 +36,52 @@ public class ProxyWorker implements Runnable{
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
-
             byte[] message = event.getData();
-            byte[] header = Arrays.copyOfRange(message, 0, AppConstants.MHEADER);
-            //System.out.println("Message is"+Utils.bytesToHex(header));
+            //Tracker will keep track of navigating through the data array
+            int tracker=0;
+
+            //This loop is to ensure that the entire data array is read
+            while(tracker < message.length){
+                byte[] header = Arrays.copyOfRange(message, tracker, tracker+AppConstants.MHEADER);
+                if(PacketAnalyzer.isMSyn(header)){
+                    InetSocketAddress msgInfo = PacketAnalyzer.fetchConnectionInfo(message);
+                    int connId=PacketAnalyzer.getConnId(header);
+                    //send back to the proxy
+                    (event.getProxy()).establishConn(msgInfo, message,connId);
+                    tracker+=AppConstants.MSYN_LEN;
+
+                }
+                else if(PacketAnalyzer.isMFin(header)){
+                    //Code commented for now
+                    //else test for MFIN
+               //     InetSocketAddress msgInfo = PacketAnalyzer.fetchConnectionInfo(message);
+
+               //     byte payload = message[AppConstants.MHEADER];
+               //     int reason = PacketAnalyzer.getMFin(payload);
+               //     int connId = PacketAnalyzer.getConnId(header);
+                   /* if(reason == AppConstants.FIN_FLAG || reason == AppConstants.RST_FLAG){
+                        //end connection
+                        (event.getProxy()).sendFin(msgInfo, reason);
+                    }
+                    */
+                    tracker+=AppConstants.MFIN_LEN;
+
+                }else{
+                    //else process and send data
+                    //messageLength is inclusive of the data header. Need to keep that in mind.
+                    int messageLength=PacketAnalyzer.getLen(header);
+                    byte[] payload = PacketAnalyzer.getPayload(message,tracker,messageLength);
+                    int seqNumber=PacketAnalyzer.getSeqNum(header);
+                    int connId=PacketAnalyzer.getConnId(header);
+                    tracker+=messageLength+AppConstants.MHEADER;
+
+                    //return to the sender
+                    (event.getProxy()).send(connId, payload,seqNumber);
+                }
+            }
 
             //test for MSYN
-            if(PacketAnalyzer.isMSyn(header)){
-                InetSocketAddress msgInfo = PacketAnalyzer.fetchConnectionInfo(message);
-                int connId=PacketAnalyzer.getConnId(header);
 
-                //send back to the proxy
-                (event.getProxy()).establishConn(msgInfo, message,connId);
-            }else if(PacketAnalyzer.isMFin(header)){
-                //else test for MFIN
-                InetSocketAddress msgInfo = PacketAnalyzer.fetchConnectionInfo(message);
-
-                byte payload = message[AppConstants.MHEADER];
-                int reason = PacketAnalyzer.getMFin(payload);
-                int connId = PacketAnalyzer.getConnId(header);
-                if(reason == AppConstants.FIN_FLAG || reason == AppConstants.RST_FLAG){
-                    //end connection
-                    (event.getProxy()).sendFin(msgInfo, reason);
-                }
-            }else{
-                //else process and send data
-                byte[] payload = PacketAnalyzer.getPayload(message);
-                int seqNumber=PacketAnalyzer.getSeqNum(header);
-                int connId=PacketAnalyzer.getConnId(header);
-
-                //return to the sender
-                (event.getProxy()).send(connId, payload,seqNumber);
-            }
 
 
         }


### PR DESCRIPTION
Made some changes to the way in which ProxyWorker handles the data. I can see all the messages being picked up now.  I've renamed the outOfOrder map as in the present design it is used to buffer all the data specific to a connection, not just the out of order ones.
Fin message is identified by FEFF and not FFFE. Need to report this to the prof.