### PR TITLE
Bidirectional support for single pipe

### DIFF
--- a/MultiTcp/src/main/java/edu/indiana/p538/ProxyThread.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/ProxyThread.java
@@ -106,8 +106,8 @@ public class ProxyThread implements Runnable{
                         }else if(PacketUtils.isMFin(header)){
                             //end connection with reason given
                             byte payload = clientInput[8];
-                            int reason = PacketUtils.getMFin(payload);
-                            if(reason == AppConstants.FIN_FLAG){
+                            String reason = PacketUtils.getMFin(payload);
+                            if(reason.equals(AppConstants.FIN_FLAG)|| reason.equals(AppConstants.RST_FLAG)){
                                 int connId = PacketUtils.getConnId(header);
                                 //end connection
                                 //TODO: IF FIN

--- a/MultiTcp/src/main/java/edu/indiana/p538/ProxyWorker.java
+++ b/MultiTcp/src/main/java/edu/indiana/p538/ProxyWorker.java
@@ -59,14 +59,15 @@ public class ProxyWorker implements Runnable{
                     //else test for MFIN
                //     InetSocketAddress msgInfo = PacketUtils.fetchConnectionInfo(message);
 
-               //     byte payload = message[AppConstants.MHEADER];
-               //     int reason = PacketUtils.getMFin(payload);
-               //     int connId = PacketUtils.getConnId(header);
-                   /* if(reason == AppConstants.FIN_FLAG || reason == AppConstants.RST_FLAG){
+                    byte payload = message[AppConstants.MHEADER];
+                    //Integer value was giving me -120. Switched to a String comparison for now. Needs to be refactored
+                    String reason = PacketUtils.getMFin(payload);
+                    int connId = PacketUtils.getConnId(header);
+                    if(reason.equals(AppConstants.FIN_FLAG) || reason.equals(AppConstants.RST_FLAG)){
                         //end connection
-                        (event.getProxy()).sendFin(msgInfo, reason);
+                        (event.getProxy()).sendFin(connId, Integer.parseInt(reason));
                     }
-                    */
+
                     tracker+=AppConstants.MFIN_LEN;
 
                 }else{


### PR DESCRIPTION
The generateDataMessage would require refactoring and I need to come up with a better way to keep track of expected sequence number for multiple pipes. Nevertheless, this works in both directions for a single pipe.